### PR TITLE
Refactoring and typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ $client->run("CREATE (n:Person) SET n += {infos}", ['infos' => ['name' => 'Ales'
 #### Reading a Result
 
 ```php
-$result = $client->run("MATCH (n:Person) RETURN n)";
+$result = $client->run("MATCH (n:Person) RETURN n");
 // a result contains always a collection (array) of Record objects
 
 // get all records

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -34,7 +34,7 @@ class ClientBuilder
     /**
      * Creates a new Client factory
      *
-     * @return \GraphAware\Neo4j\Client\ClientBuilder
+     * @return ClientBuilder
      */
     public static function create()
     {
@@ -61,6 +61,11 @@ class ClientBuilder
         $this->config['connection_manager']['preflight_env'] = $variable;
     }
 
+    /**
+     * @param string $connectionAlias
+     *
+     * @return $this
+     */
     public function setMaster($connectionAlias)
     {
         if (!isset($this->config['connections']) || !array_key_exists($connectionAlias, $this->config['connections'])) {
@@ -79,6 +84,11 @@ class ClientBuilder
         return $this;
     }
 
+    /**
+     * @param int $timeout
+     *
+     * @return $this
+     */
     public function setDefaultTimeout($timeout)
     {
         $this->config[self::$TIMEOUT_CONFIG_KEY] = (int) $timeout;
@@ -103,6 +113,9 @@ class ClientBuilder
         return new Client($connectionManager);
     }
 
+    /**
+     * @return int
+     */
     private function getDefaultTimeout()
     {
         return array_key_exists(self::$TIMEOUT_CONFIG_KEY, $this->config) ? $this->config[self::$TIMEOUT_CONFIG_KEY] : self::DEFAULT_TIMEOUT;

--- a/src/Connection/ConnectionManager.php
+++ b/src/Connection/ConnectionManager.php
@@ -19,11 +19,29 @@ class ConnectionManager
      */
     private $connections = [];
 
+    /**
+     * @var Connection|null
+     */
     private $master;
 
+    /**
+     * @param string $alias
+     * @param string $uri
+     * @param null $config
+     * @param int $timeout
+     */
     public function registerConnection($alias, $uri, $config = null, $timeout)
     {
-        $this->connections[$alias] = new Connection($alias, $uri, $config, $timeout);
+        $this->registerExistingConnection($alias, new Connection($alias, $uri, $config, $timeout));
+    }
+
+    /**
+     * @param string     $alias
+     * @param Connection $connection
+     */
+    public function registerExistingConnection($alias, Connection $connection)
+    {
+        $this->connections[$alias] = $connection;
     }
 
     /**
@@ -44,13 +62,16 @@ class ConnectionManager
         return $this->connections[$alias];
     }
 
+    /**
+     * @param string $alias
+     */
     public function setMaster($alias)
     {
         $this->master = $this->connections[$alias];
     }
 
     /**
-     * @return null|\GraphAware\Neo4j\Client\Connection\Connection
+     * @return Connection|null
      */
     public function getMasterConnection()
     {


### PR DESCRIPTION
In order to create a symfony bundle and do not BC, the method `registerExistingConnection` has been added into the `ConnectionManager` class