### PR TITLE
fixes issue #45: use RecordView::value() to access values

### DIFF
--- a/src/Formatter/RecordView.php
+++ b/src/Formatter/RecordView.php
@@ -84,7 +84,7 @@ class RecordView implements RecordViewInterface
      */
     public function nodeValue($key)
     {
-        if (!$this->hasValue($key) || !$this->get($key) instanceof Node) {
+        if (!$this->hasValue($key) || !$this->value($key) instanceof Node) {
             throw new \InvalidArgumentException(sprintf('value for %s is not of type %s', $key, Node::class));
         }
 
@@ -100,7 +100,7 @@ class RecordView implements RecordViewInterface
      */
     public function relationshipValue($key)
     {
-        if (!isset($this->values[$key]) || !$this->values[$key] instanceof Relationship) {
+        if (!isset($this->values[$key]) || !$this->value($key) instanceof Relationship) {
             throw new \InvalidArgumentException(sprintf('value for %s is not of type %s', $key, Relationship::class));
         }
 


### PR DESCRIPTION
Due to issue #45 `RecordView::relationshipValue()` did not work because undefined indexes are accessed. This commit changes `RecordView::relationshipValue()` (which directly accessed the `values` array) and `RecordView::nodeValue()` (which used `RecordView::get()` before) to use `RecordView::value()`.