### PR TITLE
fixed issue in RecordView function relationshipValue($key)

### DIFF
--- a/src/Formatter/RecordView.php
+++ b/src/Formatter/RecordView.php
@@ -100,7 +100,7 @@ class RecordView implements RecordViewInterface
      */
     public function relationshipValue($key)
     {
-        if (!isset($this->values[$key]) || !$this->value($key) instanceof Relationship) {
+        if (!$this->hasValue($key) || !$this->value($key) instanceof Relationship) {
             throw new \InvalidArgumentException(sprintf('value for %s is not of type %s', $key, Relationship::class));
         }
 


### PR DESCRIPTION
fixed issue where reference of a correct relation in recordset was given an incorrect InvalidArgumentException is returned because the value was supposed not to be not of the correct type