### PR TITLE
Be more specific with PHP versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         }
     ],
     "require": {
-      "php": ">= 5.6",
+      "php": "^5.6 || ^7.0",
       "ext-bcmath": "*",
       "ext-mbstring": "*",
       "graphaware/neo4j-bolt": "^1.5",
       "guzzlehttp/guzzle": "^6.0",
-      "symfony/event-dispatcher": "^2.7|^3.0",
+      "symfony/event-dispatcher": "^2.7 || ^3.0",
       "myclabs/php-enum": "^1.4"
     },
     "require-dev": {


### PR DESCRIPTION
We do not support PHP6 and we have no idea if we ever will support PHP8 or 9. I updated the version to be more specific. 

I did also use the proper syntax for "or".
