### PR TITLE
Optional bolt support (support php 5.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: php
 php:
+    - 5.5
     - 5.6
     - 7.0
+
+matrix:
+  include:
+  - php: "5.5"
+    env: ADD_REQ=""
+  - php: "5.6"
+    env: ADD_REQ="composer require `grep -E '(graphaware/neo4j-bolt)' composer.json | tr -d '\" ' `"
+  - php: "7.0"
+    env: ADD_REQ="composer require `grep -E '(graphaware/neo4j-bolt)' composer.json | tr -d '\" ' `"
 
 before_install:
     - sudo apt-get update > /dev/null
@@ -9,6 +19,8 @@ before_install:
     - sh -c ./build/install-jdk8.sh
     # install and launch neo4j
     - sh -c ./build/install-neo.sh
+    # Add bolt
+    - eval $ADD_REQ
     - composer self-update
     - travis_retry composer install --prefer-source --no-interaction
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Neo4j is a transactional, open-source graph database. A graph database manages d
 ### Key features
 
 * Supports multiple connections
-* Support for Bolt binary protocol
+* Support for Bolt binary protocol (PHP >= 5.6)
 * Built-in and automatic support for *Neo4j Enterprise HA Master-Slave Mode* with auto slaves fallback
 
 #### Neo4j Version Support
@@ -44,7 +44,7 @@ Neo4j is a transactional, open-source graph database. A graph database manages d
 
 ### Requirements
 
-* PHP >= 5.6
+* PHP >= 5.5 (>= 5.6 for `bolt` support)
 * ext-bcmath
 * ext-mbstring
 * A Neo4j database (minimum version 2.2.6)
@@ -85,7 +85,7 @@ $client = ClientBuilder::create()
     ->build();
 ```
 
-You're now ready to connect to your database.
+You're now ready to connect to your database.  **NOTE** Support for the `bolt` protocol is only available if running PHP version 5.6 or newer.
 
 NB: The build method will process configuration settings and return you a `Client` instance.
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,16 @@
         }
     ],
     "require": {
-      "php": ">= 5.6",
+      "php": ">= 5.5",
       "ext-bcmath": "*",
       "ext-mbstring": "*",
-      "graphaware/neo4j-bolt": "^1.5",
       "guzzlehttp/guzzle": "^6.0",
       "symfony/event-dispatcher": "^2.7|^3.0",
-      "myclabs/php-enum": "^1.4"
+      "myclabs/php-enum": "^1.4",
+      "graphaware/neo4j-common": "^3.0"
+    },
+    "suggest": {
+      "graphaware/neo4j-bolt": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -165,6 +165,9 @@ class Connection
         $params = parse_url($this->uri);
 
         if (preg_match('/bolt/', $this->uri)) {
+            if (!class_exists(BoltDriver::class)) {
+                throw new \RuntimeException(sprintf("Bolt support is not available."));
+            }
             $port = isset($params['port']) ? (int) $params['port'] : BoltDriver::DEFAULT_TCP_PORT;
             $uri = sprintf('%s://%s:%d', $params['scheme'], $params['host'], $port);
             $config = null;


### PR DESCRIPTION
PHP 5.5 is still in [wide use](https://seld.be/notes/php-versions-stats-2016-1-edition) but it is impossible to use this library with anything less than PHP 5.6.  As stated in #47, the requirement for PHP 5.6 comes from the fact that the `bolt` driver needs the 64-bit support in the `pack`/`unpack` functions.  It seems to me that a decent compromise would be to make `bolt` support optional and only available in PHP versions that support it.  The `http` driver can then be used by those running lower versions of PHP.