### PR TITLE
Use HTTPlug

### DIFF
--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ $options = [
 ];
 $httpClient = new Client(null, null, $options);
 
-$config = \GraphAware\Neo4j\Client\HttpDriver\Configuration::craete($httpClient);
+$config = \GraphAware\Neo4j\Client\HttpDriver\Configuration::create($httpClient);
 $driver = \GraphAware\Bolt\GraphDatabase::driver('bolt://hodccomjfkgdenl.dbs.gdb.com:24786', $config);
 $session = $driver->session();
 ```

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ The event dispatcher is available via the client with the `$client->getEventDisp
 
 ### Settings
 
-#### Timeout
+#### Timeout (deprecated)
 
 You can configure a global timeout for the connections :
 
@@ -482,6 +482,8 @@ $client = ClientBuilder::create()
 
 The timeout by default is 5 seconds.
 
+This feature is deprecated and will be removed in version 5. See Http client settings below. 
+
 ### TLS
 
 You can enable TLS encryption for the Bolt Protocol by passing a `Configuration` instance when building the connection, here
@@ -492,6 +494,26 @@ $config = \GraphAware\Bolt\Configuration::newInstance()
     ->withCredentials('bolttest', 'L7n7SfTSj')
     ->withTLSMode(\GraphAware\Bolt\Configuration::TLSMODE_REQUIRED);
 
+$driver = \GraphAware\Bolt\GraphDatabase::driver('bolt://hodccomjfkgdenl.dbs.gdb.com:24786', $config);
+$session = $driver->session();
+```
+
+#### HTTP client settings
+
+We use HTTPlug to give you full control of the HTTP client. Version 4 of the Neo4jClient comes with Guzzle6 by default
+to preserve backward compatibility. Version 5 will give you the option to choose whatever client you want. Read more
+about HTTPlug [in their documentation](http://docs.php-http.org/en/latest/httplug/users.html).
+
+To configure your client you may add it to `Configuration`. 
+
+```php
+$options = [
+    CURLOPT_CONNECTTIMEOUT => 3, // The number of seconds to wait while trying to connect.
+    CURLOPT_SSL_VERIFYPEER => false // Stop cURL from verifying the peer's certificate
+];
+$httpClient = new Client(null, null, $options);
+
+$config = \GraphAware\Neo4j\Client\HttpDriver\Configuration::craete($httpClient);
 $driver = \GraphAware\Bolt\GraphDatabase::driver('bolt://hodccomjfkgdenl.dbs.gdb.com:24786', $config);
 $session = $driver->session();
 ```

--- a/composer.json
+++ b/composer.json
@@ -25,14 +25,19 @@
       "ext-bcmath": "*",
       "ext-mbstring": "*",
       "graphaware/neo4j-bolt": "^1.5",
-      "guzzlehttp/guzzle": "^6.0",
       "symfony/event-dispatcher": "^2.7 || ^3.0",
-      "myclabs/php-enum": "^1.4"
+      "myclabs/php-enum": "^1.4",
+      "php-http/httplug": "^1.0",
+      "php-http/message-factory": "^1.0",
+      "php-http/client-common": "^1.0",
+      "php-http/discovery": "^1.0",
+
+      "php-http/message": "^1.0",
+      "php-http/guzzle6-adapter": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*",
         "symfony/stopwatch": "^3.0"
-
     },
     "autoload": {
         "psr-4": {

--- a/src/HttpDriver/Configuration.php
+++ b/src/HttpDriver/Configuration.php
@@ -3,31 +3,92 @@
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
 use GraphAware\Common\Driver\ConfigInterface;
+use Http\Client\HttpClient;
+use Http\Discovery\HttpClientDiscovery;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\RequestFactory;
 
 class Configuration implements ConfigInterface
 {
     /**
      * @var int
+     * @deprecated Will be removed in 5.0
      */
     protected $timeout;
 
     /**
      * @var string
+     * @deprecated Will be removed in 5.0
      */
     protected $curlInterface;
 
     /**
+     * @var HttpClient
+     */
+    private $httpClient;
+
+    /**
+     * @var RequestFactory
+     */
+    private $requestFactory;
+
+    /**
      * @return Configuration
      */
-    public static function create()
+    public static function create(HttpClient $httpClient = null, RequestFactory $requestFactory = null)
     {
-        return new self();
+        $config = new self();
+        $config->httpClient = $httpClient ?: HttpClientDiscovery::find();
+        $config->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
+
+        return $config;
+    }
+
+    /**
+     * @return HttpClient
+     */
+    public function getHttpClient()
+    {
+        return $this->httpClient;
+    }
+
+    /**
+     * @param HttpClient $httpClient
+     *
+     * @return Configuration
+     */
+    public function setHttpClient(HttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+
+        return $this;
+    }
+
+    /**
+     * @return RequestFactory
+     */
+    public function getRequestFactory()
+    {
+        return $this->requestFactory;
+    }
+
+    /**
+     * @param RequestFactory $requestFactory
+     *
+     * @return Configuration
+     */
+    public function setRequestFactory(RequestFactory $requestFactory)
+    {
+        $this->requestFactory = $requestFactory;
+
+        return $this;
     }
 
     /**
      * @param int $timeout
      *
      * @return Configuration
+     * @deprecated Will be removed in 5.0
      */
     public function withTimeout($timeout)
     {
@@ -40,6 +101,7 @@ class Configuration implements ConfigInterface
      * @param string $interface
      *
      * @return $this
+     * @deprecated Will be removed in 5.0
      */
     public function withCurlInterface($interface)
     {
@@ -50,6 +112,7 @@ class Configuration implements ConfigInterface
 
     /**
      * @return int
+     * @deprecated Will be removed in 5.0
      */
     public function getTimeout()
     {
@@ -58,6 +121,7 @@ class Configuration implements ConfigInterface
 
     /**
      * @return string
+     * @deprecated Will be removed in 5.0
      */
     public function getCurlInterface()
     {

--- a/src/HttpDriver/Configuration.php
+++ b/src/HttpDriver/Configuration.php
@@ -59,9 +59,10 @@ class Configuration implements ConfigInterface
      */
     public function setHttpClient(HttpClient $httpClient)
     {
-        $this->httpClient = $httpClient;
+        $new = clone $this;
+        $new->httpClient = $httpClient;
 
-        return $this;
+        return $new;
     }
 
     /**
@@ -79,9 +80,10 @@ class Configuration implements ConfigInterface
      */
     public function setRequestFactory(RequestFactory $requestFactory)
     {
-        $this->requestFactory = $requestFactory;
+        $new = clone $this;
+        $new->requestFactory = $requestFactory;
 
-        return $this;
+        return $new;
     }
 
     /**

--- a/src/HttpDriver/Driver.php
+++ b/src/HttpDriver/Driver.php
@@ -10,9 +10,9 @@
  */
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
-use GraphAware\Common\Driver\DriverInterface;
-use GuzzleHttp\Client;
 use GraphAware\Common\Driver\ConfigInterface;
+use GraphAware\Common\Driver\DriverInterface;
+use Http\Adapter\Guzzle6\Client;
 
 class Driver implements DriverInterface
 {
@@ -43,6 +43,23 @@ class Driver implements DriverInterface
      */
     public function session()
     {
+        return new Session($this->uri, $this->getHttpClient(), $this->config);
+    }
+
+    /**
+     * @return string
+     */
+    public function getUri()
+    {
+        return $this->uri;
+    }
+
+    /**
+     *
+     * @return \Http\Client\HttpClient
+     */
+    private function getHttpClient()
+    {
         $options = [];
         if (null !== $this->config->getTimeout()) {
             $options['timeout'] = $this->config->getTimeout();
@@ -52,18 +69,15 @@ class Driver implements DriverInterface
             $options['curl'][10062] = $this->config->getCurlInterface();
         }
 
+        if (empty($options)) {
+            return $this->config->getHttpClient();
+        }
+
+        // This is to keep BC. Will be removed in 5.0
+
         $options['curl'][74] = true;
         $options['curl'][75] = true;
 
-        return new Session(
-            $this->uri, new Client($options), $this->config);
-    }
-
-    /**
-     * @return string
-     */
-    public function getUri()
-    {
-        return $this->uri;
+        return Client::createWithConfig($options);
     }
 }

--- a/src/HttpDriver/Session.php
+++ b/src/HttpDriver/Session.php
@@ -15,9 +15,16 @@ use GraphAware\Common\Driver\SessionInterface;
 use GraphAware\Common\Transaction\TransactionInterface;
 use GraphAware\Neo4j\Client\Exception\Neo4jException;
 use GraphAware\Neo4j\Client\Formatter\ResponseFormatter;
-use GuzzleHttp\Client;
-use GuzzleHttp\Exception\RequestException;
-use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Client as GuzzleClient;
+use Http\Adapter\Guzzle6\Client;
+use Http\Client\Common\Plugin\ErrorPlugin;
+use Http\Client\Common\PluginClient;
+use Http\Client\Exception\HttpException;
+use Http\Client\Exception\RequestException;
+use Http\Client\HttpClient;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Message\RequestFactory;
+use Psr\Http\Message\RequestInterface;
 
 class Session implements SessionInterface
 {
@@ -27,7 +34,7 @@ class Session implements SessionInterface
     protected $uri;
 
     /**
-     * @var Client
+     * @var HttpClient
      */
     protected $httpClient;
 
@@ -42,21 +49,34 @@ class Session implements SessionInterface
     public $transaction;
 
     /**
-     * @var ConfigInterface
+     * @var Configuration
      */
     protected $config;
 
     /**
-     * @param string          $uri
-     * @param Client          $httpClient
-     * @param ConfigInterface $config
+     * @var RequestFactory
      */
-    public function __construct($uri, Client $httpClient, ConfigInterface $config)
+    private $requestFactory;
+
+    /**
+     * @param string                        $uri
+     * @param GuzzleClient|HttpClient       $httpClient
+     * @param Configuration|ConfigInterface $config
+     */
+    public function __construct($uri, $httpClient, ConfigInterface $config)
     {
+        if ($httpClient instanceof GuzzleClient) {
+            @trigger_error('Passing a Guzzle client to Session is deprecrated. Will be removed in 5.0. Use a HTTPlug client');
+            $httpClient = new Client($httpClient);
+        } elseif (!$httpClient instanceof HttpClient) {
+            throw new \RuntimeException('Second argument to Session::__construct must be an instance of Http\Client\HttpClient.');
+        }
+
         $this->uri = $uri;
-        $this->httpClient = $httpClient;
+        $this->httpClient = new PluginClient($httpClient, [new ErrorPlugin()]);
         $this->responseFormatter = new ResponseFormatter();
         $this->config = $config;
+        $this->requestFactory = $config->getRequestFactory();
     }
 
     /**
@@ -120,7 +140,7 @@ class Session implements SessionInterface
     {
         $request = $this->prepareRequest($pipeline);
         try {
-            $response = $this->httpClient->send($request);
+            $response = $this->httpClient->sendRequest($request);
             $data = json_decode((string) $response->getBody(), true);
             if (!empty($data['errors'])) {
                 $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $data['errors'][0]['code'], $data['errors'][0]['message']);
@@ -128,32 +148,27 @@ class Session implements SessionInterface
                 $exception->setNeo4jStatusCode($data['errors'][0]['code']);
 
                 throw $exception;
-
             }
             $results = $this->responseFormatter->format(json_decode($response->getBody(), true), $pipeline->statements());
 
             return $results;
-        } catch (RequestException $e) {
-            if ($e->hasResponse()) {
-                $body = json_decode($e->getResponse()->getBody(), true);
-                if (!isset($body['code'])) {
-                    throw $e;
-                }
-                $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
-                $exception = new Neo4jException($msg);
-                $exception->setNeo4jStatusCode($body['errors'][0]['code']);
-
-                throw $exception;
+        } catch (HttpException $e) {
+            $body = json_decode($e->getResponse()->getBody(), true);
+            if (!isset($body['code'])) {
+                throw $e;
             }
+            $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
+            $exception = new Neo4jException($msg, 0, $e);
+            $exception->setNeo4jStatusCode($body['errors'][0]['code']);
 
-            throw $e;
+            throw $exception;
         }
     }
 
     /**
      * @param Pipeline $pipeline
      *
-     * @return Request
+     * @return RequestInterface
      */
     public function prepareRequest(Pipeline $pipeline)
     {
@@ -180,7 +195,7 @@ class Session implements SessionInterface
             ],
         ];
 
-        return new Request('POST', sprintf('%s/db/data/transaction/commit', $this->uri), $headers, $body);
+        return $this->requestFactory->createRequest('POST', sprintf('%s/db/data/transaction/commit', $this->uri), $headers, $body);
     }
 
     private function formatParams(array $params)
@@ -205,24 +220,20 @@ class Session implements SessionInterface
      */
     public function begin()
     {
-        $request = new Request('POST', sprintf('%s/db/data/transaction', $this->uri));
+        $request = $this->requestFactory->createRequest('POST', sprintf('%s/db/data/transaction', $this->uri));
 
         try {
-            return $this->httpClient->send($request);
-        } catch (RequestException $e) {
-            if ($e->hasResponse()) {
-                $body = json_decode($e->getResponse()->getBody(), true);
-                if (!isset($body['code'])) {
-                    throw $e;
-                }
-                $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
-                $exception = new Neo4jException($msg);
-                $exception->setNeo4jStatusCode($body['errors'][0]['code']);
-
-                throw $exception;
+            return $this->httpClient->sendRequest($request);
+        } catch (HttpException $e) {
+            $body = json_decode($e->getResponse()->getBody(), true);
+            if (!isset($body['code'])) {
+                throw $e;
             }
+            $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
+            $exception = new Neo4jException($msg, 0, $e);
+            $exception->setNeo4jStatusCode($body['errors'][0]['code']);
 
-            throw $e;
+            throw $exception;
         }
     }
 
@@ -260,10 +271,10 @@ class Session implements SessionInterface
             'statements' => $statements,
         ]);
 
-        $request = new Request('POST', sprintf('%s/db/data/transaction/%d', $this->uri, $transactionId), $headers, $body);
+        $request = $this->requestFactory->createRequest('POST', sprintf('%s/db/data/transaction/%d', $this->uri, $transactionId), $headers, $body);
 
         try {
-            $response = $this->httpClient->send($request);
+            $response = $this->httpClient->sendRequest($request);
             $data = json_decode((string) $response->getBody(), true);
             if (!empty($data['errors'])) {
                 $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $data['errors'][0]['code'], $data['errors'][0]['message']);
@@ -271,23 +282,19 @@ class Session implements SessionInterface
                 $exception->setNeo4jStatusCode($data['errors'][0]['code']);
 
                 throw $exception;
-
             }
+
             return $this->responseFormatter->format(json_decode($response->getBody(), true), $statementsStack);
-        } catch (RequestException $e) {
-            if ($e->hasResponse()) {
-                $body = json_decode($e->getResponse()->getBody(), true);
-                if (!isset($body['code'])) {
-                    throw $e;
-                }
-                $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
-                $exception = new Neo4jException($msg);
-                $exception->setNeo4jStatusCode($body['errors'][0]['code']);
-
-                throw $exception;
+        } catch (HttpException $e) {
+            $body = json_decode($e->getResponse()->getBody(), true);
+            if (!isset($body['code'])) {
+                throw $e;
             }
+            $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
+            $exception = new Neo4jException($msg, 0, $e);
+            $exception->setNeo4jStatusCode($body['errors'][0]['code']);
 
-            throw $e;
+            throw $exception;
         }
     }
 
@@ -298,9 +305,9 @@ class Session implements SessionInterface
      */
     public function commitTransaction($transactionId)
     {
-        $request = new Request('POST', sprintf('%s/db/data/transaction/%d/commit', $this->uri, $transactionId));
+        $request = $this->requestFactory->createRequest('POST', sprintf('%s/db/data/transaction/%d/commit', $this->uri, $transactionId));
         try {
-            $response = $this->httpClient->send($request);
+            $response = $this->httpClient->sendRequest($request);
             $data = json_decode((string) $response->getBody(), true);
             if (!empty($data['errors'])) {
                 $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $data['errors'][0]['code'], $data['errors'][0]['message']);
@@ -309,20 +316,16 @@ class Session implements SessionInterface
                 throw $exception;
 
             }
-        } catch (RequestException $e) {
-            if ($e->hasResponse()) {
-                $body = json_decode($e->getResponse()->getBody(), true);
-                if (!isset($body['code'])) {
-                    throw $e;
-                }
-                $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
-                $exception = new Neo4jException($msg);
-                $exception->setNeo4jStatusCode($body['errors'][0]['code']);
-
-                throw $exception;
+        } catch (HttpException $e) {
+            $body = json_decode($e->getResponse()->getBody(), true);
+            if (!isset($body['code'])) {
+                throw $e;
             }
+            $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
+            $exception = new Neo4jException($msg, 0, $e);
+            $exception->setNeo4jStatusCode($body['errors'][0]['code']);
 
-            throw $e;
+            throw $exception;
         }
     }
 
@@ -333,24 +336,20 @@ class Session implements SessionInterface
      */
     public function rollbackTransaction($transactionId)
     {
-        $request = new Request('DELETE', sprintf('%s/db/data/transaction/%d', $this->uri, $transactionId));
+        $request = $this->requestFactory->createRequest('DELETE', sprintf('%s/db/data/transaction/%d', $this->uri, $transactionId));
 
         try {
-            $this->httpClient->send($request);
-        } catch (RequestException $e) {
-            if ($e->hasResponse()) {
-                $body = json_decode($e->getResponse()->getBody(), true);
-                if (!isset($body['code'])) {
-                    throw $e;
-                }
-                $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
-                $exception = new Neo4jException($msg);
-                $exception->setNeo4jStatusCode($body['errors'][0]['code']);
-
-                throw $exception;
+            $this->httpClient->sendRequest($request);
+        } catch (HttpException $e) {
+            $body = json_decode($e->getResponse()->getBody(), true);
+            if (!isset($body['code'])) {
+                throw $e;
             }
+            $msg = sprintf('Neo4j Exception with code "%s" and message "%s"', $body['errors'][0]['code'], $body['errors'][0]['message']);
+            $exception = new Neo4jException($msg, 0, $e);
+            $exception->setNeo4jStatusCode($body['errors'][0]['code']);
 
-            throw $e;
+            throw $exception;
         }
     }
 }


### PR DESCRIPTION
This is a BC update to use HTTPlug. We still use the Guzzle adapter.

To make this really interoperable we should remove the following form composer.json. But that would be a BC break. 

```json
"php-http/message": "^1.0",
"php-http/guzzle6-adapter": "^1.0"
```

This will fix #84 