### PR TITLE
Avoid using ConfigInterface since it does not provide any type safety

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,6 @@
         "psr-4": {
             "GraphAware\\Neo4j\\Client\\Tests\\": "tests/"
         }
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
       "php": "^5.6 || ^7.0",
       "ext-bcmath": "*",
       "ext-mbstring": "*",
+      "graphaware/neo4j-common": "^3.4",
       "graphaware/neo4j-bolt": "^1.5",
       "symfony/event-dispatcher": "^2.7 || ^3.0",
       "myclabs/php-enum": "^1.4",

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -11,7 +11,6 @@
 
 namespace GraphAware\Neo4j\Client;
 
-use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Neo4j\Client\Connection\ConnectionManager;
 use GraphAware\Neo4j\Client\HttpDriver\Configuration;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -57,13 +56,13 @@ class ClientBuilder
     /**
      * Add a connection to the handled connections.
      *
-     * @param string          $alias
-     * @param string          $uri
-     * @param ConfigInterface $config
+     * @param string $alias
+     * @param string $uri
+     * @param mixed  $config
      *
      * @return ClientBuilder
      */
-    public function addConnection($alias, $uri, ConfigInterface $config = null)
+    public function addConnection($alias, $uri, $config = null)
     {
         $this->config['connections'][$alias]['uri'] = $uri;
         if (null !== $config) {

--- a/src/ClientBuilder.php
+++ b/src/ClientBuilder.php
@@ -11,6 +11,8 @@
 
 namespace GraphAware\Neo4j\Client;
 
+use GraphAware\Common\Connection\BaseConfiguration;
+use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Neo4j\Client\Connection\ConnectionManager;
 use GraphAware\Neo4j\Client\HttpDriver\Configuration;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -56,13 +58,13 @@ class ClientBuilder
     /**
      * Add a connection to the handled connections.
      *
-     * @param string $alias
-     * @param string $uri
-     * @param mixed  $config
+     * @param string            $alias
+     * @param string            $uri
+     * @param BaseConfiguration $config
      *
      * @return ClientBuilder
      */
-    public function addConnection($alias, $uri, $config = null)
+    public function addConnection($alias, $uri, ConfigInterface $config = null)
     {
         $this->config['connections'][$alias]['uri'] = $uri;
         if (null !== $config) {

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -15,6 +15,7 @@ use GraphAware\Bolt\Configuration as BoltConfiguration;
 use GraphAware\Bolt\Driver as BoltDriver;
 use GraphAware\Bolt\Exception\MessageFailureException;
 use GraphAware\Bolt\GraphDatabase as BoltGraphDB;
+use GraphAware\Common\Connection\BaseConfiguration;
 use GraphAware\Common\Cypher\Statement;
 use GraphAware\Neo4j\Client\Exception\Neo4jException;
 use GraphAware\Neo4j\Client\HttpDriver\GraphDatabase as HttpGraphDB;
@@ -50,9 +51,9 @@ class Connection
     /**
      * Connection constructor.
      *
-     * @param string             $alias
-     * @param string             $uri
-     * @param Configuration|null $config
+     * @param string                 $alias
+     * @param string                 $uri
+     * @param BaseConfiguration|null $config
      */
     public function __construct($alias, $uri, $config = null)
     {
@@ -170,7 +171,7 @@ class Connection
             $uri = sprintf('%s://%s:%d', $params['scheme'], $params['host'], $port);
             $config = null;
             if (isset($params['user']) && isset($params['pass'])) {
-                $config = BoltConfiguration::newInstance()->withCredentials($params['user'], $params['pass']);
+                $config = BoltConfiguration::create()->withCredentials($params['user'], $params['pass']);
             }
             $this->driver = BoltGraphDB::driver($uri, $config);
         } elseif (preg_match('/http/', $this->uri)) {

--- a/src/Connection/Connection.php
+++ b/src/Connection/Connection.php
@@ -11,7 +11,7 @@
 
 namespace GraphAware\Neo4j\Client\Connection;
 
-use GraphAware\Bolt\Configuration;
+use GraphAware\Bolt\Configuration as BoltConfiguration;
 use GraphAware\Bolt\Driver as BoltDriver;
 use GraphAware\Bolt\Exception\MessageFailureException;
 use GraphAware\Bolt\GraphDatabase as BoltGraphDB;
@@ -170,7 +170,7 @@ class Connection
             $uri = sprintf('%s://%s:%d', $params['scheme'], $params['host'], $port);
             $config = null;
             if (isset($params['user']) && isset($params['pass'])) {
-                $config = Configuration::newInstance()->withCredentials($params['user'], $params['pass']);
+                $config = BoltConfiguration::newInstance()->withCredentials($params['user'], $params['pass']);
             }
             $this->driver = BoltGraphDB::driver($uri, $config);
         } elseif (preg_match('/http/', $this->uri)) {

--- a/src/Connection/ConnectionManager.php
+++ b/src/Connection/ConnectionManager.php
@@ -11,6 +11,8 @@
 
 namespace GraphAware\Neo4j\Client\Connection;
 
+use GraphAware\Common\Connection\BaseConfiguration;
+
 class ConnectionManager
 {
     /**
@@ -24,9 +26,9 @@ class ConnectionManager
     private $master;
 
     /**
-     * @param string             $alias
-     * @param string             $uri
-     * @param null|Configuration $config
+     * @param string                 $alias
+     * @param string                 $uri
+     * @param BaseConfiguration|null $config
      */
     public function registerConnection($alias, $uri, $config = null)
     {

--- a/src/Connection/ConnectionManager.php
+++ b/src/Connection/ConnectionManager.php
@@ -11,8 +11,6 @@
 
 namespace GraphAware\Neo4j\Client\Connection;
 
-use GraphAware\Neo4j\Client\HttpDriver\Configuration;
-
 class ConnectionManager
 {
     /**

--- a/src/HttpDriver/Configuration.php
+++ b/src/HttpDriver/Configuration.php
@@ -16,7 +16,7 @@ use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\RequestFactory;
-use GraphAware\Common\Connection\Configuration as BaseConfiguration;
+use GraphAware\Common\Connection\BaseConfiguration;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>

--- a/src/HttpDriver/Configuration.php
+++ b/src/HttpDriver/Configuration.php
@@ -16,8 +16,12 @@ use Http\Client\HttpClient;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\MessageFactoryDiscovery;
 use Http\Message\RequestFactory;
+use GraphAware\Common\Connection\Configuration as BaseConfiguration;
 
-class Configuration implements ConfigInterface
+/**
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class Configuration extends BaseConfiguration implements ConfigInterface
 {
     /**
      * @var int
@@ -32,33 +36,14 @@ class Configuration implements ConfigInterface
     protected $curlInterface;
 
     /**
-     * @var HttpClient
-     */
-    private $httpClient;
-
-    /**
-     * @var RequestFactory
-     */
-    private $requestFactory;
-
-    /**
      * @return Configuration
      */
     public static function create(HttpClient $httpClient = null, RequestFactory $requestFactory = null)
     {
-        $config = new self();
-        $config->httpClient = $httpClient ?: HttpClientDiscovery::find();
-        $config->requestFactory = $requestFactory ?: MessageFactoryDiscovery::find();
-
-        return $config;
-    }
-
-    /**
-     * @return HttpClient
-     */
-    public function getHttpClient()
-    {
-        return $this->httpClient;
+        return new self([
+            'http_client' => $httpClient ?: HttpClientDiscovery::find(),
+            'request_factory' => $requestFactory ?: MessageFactoryDiscovery::find(),
+        ]);
     }
 
     /**
@@ -68,18 +53,7 @@ class Configuration implements ConfigInterface
      */
     public function setHttpClient(HttpClient $httpClient)
     {
-        $new = clone $this;
-        $new->httpClient = $httpClient;
-
-        return $new;
-    }
-
-    /**
-     * @return RequestFactory
-     */
-    public function getRequestFactory()
-    {
-        return $this->requestFactory;
+        return $this->setValue('http_client', $httpClient);
     }
 
     /**
@@ -89,36 +63,29 @@ class Configuration implements ConfigInterface
      */
     public function setRequestFactory(RequestFactory $requestFactory)
     {
-        $new = clone $this;
-        $new->requestFactory = $requestFactory;
-
-        return $new;
+        return $this->setValue('request_factory', $requestFactory);
     }
 
     /**
      * @param int $timeout
      *
      * @return Configuration
-     * @deprecated Will be removed in 5.0
+     * @deprecated Will be removed in 5.0. The Timeout option will disappear.
      */
     public function withTimeout($timeout)
     {
-        $this->timeout = $timeout;
-
-        return $this;
+        return $this->setValue('timeout', $timeout);
     }
 
     /**
      * @param string $interface
      *
      * @return $this
-     * @deprecated Will be removed in 5.0
+     * @deprecated Will be removed in 5.0. The CurlInterface option will disappear.
      */
     public function withCurlInterface($interface)
     {
-        $this->curlInterface = $interface;
-
-        return $this;
+        return $this->setValue('curl_interface', $interface);
     }
 
     /**
@@ -127,15 +94,15 @@ class Configuration implements ConfigInterface
      */
     public function getTimeout()
     {
-        return $this->timeout;
+        return $this->getValue('timeout');
     }
 
     /**
      * @return string
-     * @deprecated Will be removed in 5.0
+     * @deprecated Will be removed in 5.0.
      */
     public function getCurlInterface()
     {
-        return $this->curlInterface;
+        return $this->getValue('curl_interface');
     }
 }

--- a/src/HttpDriver/Driver.php
+++ b/src/HttpDriver/Driver.php
@@ -76,7 +76,7 @@ class Driver implements DriverInterface
         }
 
         if (empty($options)) {
-            return $this->config->get('http_client');
+            return $this->config->getValue('http_client');
         }
 
         // This is to keep BC. Will be removed in 5.0

--- a/src/HttpDriver/Driver.php
+++ b/src/HttpDriver/Driver.php
@@ -11,7 +11,6 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
-use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\DriverInterface;
 use Http\Adapter\Guzzle6\Client;
 
@@ -33,8 +32,12 @@ class Driver implements DriverInterface
      * @param string        $uri
      * @param Configuration $config
      */
-    public function __construct($uri, ConfigInterface $config = null)
+    public function __construct($uri, $config = null)
     {
+        if (null !== $config && !$config instanceof Configuration) {
+            throw new \RuntimeException(sprintf('Second argument to "%s" must be null or "%s"', __CLASS__, Configuration::class));
+        }
+
         $this->uri = $uri;
         $this->config = null !== $config ? $config : Configuration::create();
     }

--- a/src/HttpDriver/Driver.php
+++ b/src/HttpDriver/Driver.php
@@ -11,6 +11,8 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
+use GraphAware\Common\Connection\BaseConfiguration;
+use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\DriverInterface;
 use Http\Adapter\Guzzle6\Client;
 
@@ -32,7 +34,7 @@ class Driver implements DriverInterface
      * @param string        $uri
      * @param Configuration $config
      */
-    public function __construct($uri, $config = null)
+    public function __construct($uri, ConfigInterface $config = null)
     {
         if (null !== $config && !$config instanceof Configuration) {
             throw new \RuntimeException(sprintf('Second argument to "%s" must be null or "%s"', __CLASS__, Configuration::class));
@@ -65,16 +67,16 @@ class Driver implements DriverInterface
     private function getHttpClient()
     {
         $options = [];
-        if (null !== $this->config->getTimeout()) {
-            $options['timeout'] = $this->config->getTimeout();
+        if ($this->config->hasValue('timeout')) {
+            $options['timeout'] = $this->config->getValue('timeout');
         }
 
-        if (null !== $this->config->getCurlInterface()) {
-            $options['curl'][10062] = $this->config->getCurlInterface();
+        if ($this->config->hasValue('curl_interface')) {
+            $options['curl'][10062] = $this->config->getValue('curl_interface');
         }
 
         if (empty($options)) {
-            return $this->config->getHttpClient();
+            return $this->config->get('http_client');
         }
 
         // This is to keep BC. Will be removed in 5.0

--- a/src/HttpDriver/Driver.php
+++ b/src/HttpDriver/Driver.php
@@ -31,13 +31,13 @@ class Driver implements DriverInterface
     protected $config;
 
     /**
-     * @param string        $uri
-     * @param Configuration $config
+     * @param string            $uri
+     * @param BaseConfiguration $config
      */
     public function __construct($uri, ConfigInterface $config = null)
     {
-        if (null !== $config && !$config instanceof Configuration) {
-            throw new \RuntimeException(sprintf('Second argument to "%s" must be null or "%s"', __CLASS__, Configuration::class));
+        if (null !== $config && !$config instanceof BaseConfiguration) {
+            throw new \RuntimeException(sprintf('Second argument to "%s" must be null or "%s"', __CLASS__, BaseConfiguration::class));
         }
 
         $this->uri = $uri;

--- a/src/HttpDriver/GraphDatabase.php
+++ b/src/HttpDriver/GraphDatabase.php
@@ -17,8 +17,8 @@ use GraphAware\Common\GraphDatabaseInterface;
 class GraphDatabase implements GraphDatabaseInterface
 {
     /**
-     * @param string               $uri
-     * @param ConfigInterface|null $config
+     * @param string             $uri
+     * @param Configuration|null $config
      *
      * @return Driver
      */

--- a/src/HttpDriver/GraphDatabase.php
+++ b/src/HttpDriver/GraphDatabase.php
@@ -11,6 +11,7 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
+use GraphAware\Common\Connection\Configuration;
 use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\GraphDatabaseInterface;
 

--- a/src/HttpDriver/GraphDatabase.php
+++ b/src/HttpDriver/GraphDatabase.php
@@ -11,15 +11,15 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
-use GraphAware\Common\Connection\Configuration;
+use GraphAware\Common\Connection\BaseConfiguration;
 use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\GraphDatabaseInterface;
 
 class GraphDatabase implements GraphDatabaseInterface
 {
     /**
-     * @param string             $uri
-     * @param Configuration|null $config
+     * @param string                 $uri
+     * @param BaseConfiguration|null $config
      *
      * @return Driver
      */

--- a/src/HttpDriver/Session.php
+++ b/src/HttpDriver/Session.php
@@ -11,6 +11,7 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
+use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\SessionInterface;
 use GraphAware\Common\Transaction\TransactionInterface;
 use GraphAware\Neo4j\Client\Exception\Neo4jException;
@@ -63,7 +64,7 @@ class Session implements SessionInterface
      * @param GuzzleClient|HttpClient $httpClient
      * @param Configuration           $config
      */
-    public function __construct($uri, $httpClient, $config)
+    public function __construct($uri, $httpClient, ConfigInterface $config)
     {
         if ($httpClient instanceof GuzzleClient) {
             @trigger_error('Passing a Guzzle client to Session is deprecrated. Will be removed in 5.0. Use a HTTPlug client');

--- a/src/HttpDriver/Session.php
+++ b/src/HttpDriver/Session.php
@@ -11,6 +11,7 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
+use GraphAware\Common\Connection\BaseConfiguration;
 use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\SessionInterface;
 use GraphAware\Common\Transaction\TransactionInterface;
@@ -62,7 +63,7 @@ class Session implements SessionInterface
     /**
      * @param string                  $uri
      * @param GuzzleClient|HttpClient $httpClient
-     * @param Configuration           $config
+     * @param BaseConfiguration       $config
      */
     public function __construct($uri, $httpClient, ConfigInterface $config)
     {
@@ -73,15 +74,15 @@ class Session implements SessionInterface
             throw new \RuntimeException('Second argument to Session::__construct must be an instance of Http\Client\HttpClient.');
         }
 
-        if (null !== $config && !$config instanceof Configuration) {
-            throw new \RuntimeException(sprintf('Third argument to "%s" must be null or "%s"', __CLASS__, Configuration::class));
+        if (null !== $config && !$config instanceof BaseConfiguration) {
+            throw new \RuntimeException(sprintf('Third argument to "%s" must be null or "%s"', __CLASS__, BaseConfiguration::class));
         }
 
         $this->uri = $uri;
         $this->httpClient = new PluginClient($httpClient, [new ErrorPlugin()]);
         $this->responseFormatter = new ResponseFormatter();
         $this->config = $config;
-        $this->requestFactory = $config->getRequestFactory();
+        $this->requestFactory = $config->getValue('request_factory');
     }
 
     /**

--- a/src/HttpDriver/Session.php
+++ b/src/HttpDriver/Session.php
@@ -11,7 +11,6 @@
 
 namespace GraphAware\Neo4j\Client\HttpDriver;
 
-use GraphAware\Common\Driver\ConfigInterface;
 use GraphAware\Common\Driver\SessionInterface;
 use GraphAware\Common\Transaction\TransactionInterface;
 use GraphAware\Neo4j\Client\Exception\Neo4jException;
@@ -60,17 +59,21 @@ class Session implements SessionInterface
     private $requestFactory;
 
     /**
-     * @param string                        $uri
-     * @param GuzzleClient|HttpClient       $httpClient
-     * @param Configuration|ConfigInterface $config
+     * @param string                  $uri
+     * @param GuzzleClient|HttpClient $httpClient
+     * @param Configuration           $config
      */
-    public function __construct($uri, $httpClient, ConfigInterface $config)
+    public function __construct($uri, $httpClient, $config)
     {
         if ($httpClient instanceof GuzzleClient) {
             @trigger_error('Passing a Guzzle client to Session is deprecrated. Will be removed in 5.0. Use a HTTPlug client');
             $httpClient = new Client($httpClient);
         } elseif (!$httpClient instanceof HttpClient) {
             throw new \RuntimeException('Second argument to Session::__construct must be an instance of Http\Client\HttpClient.');
+        }
+
+        if (null !== $config && !$config instanceof Configuration) {
+            throw new \RuntimeException(sprintf('Third argument to "%s" must be null or "%s"', __CLASS__, Configuration::class));
         }
 
         $this->uri = $uri;


### PR DESCRIPTION
Instead we are using the Configuration implementations or mixed.
We throw exceptions on places that would have generated Errors if the wrong Configuration implementation was provided.

Related to https://github.com/graphaware/neo4j-bolt-php/pull/19 and https://github.com/graphaware/neo4j-php-commons/pull/8