### PR TITLE
Headers should not be in double array

### DIFF
--- a/src/HttpDriver/Session.php
+++ b/src/HttpDriver/Session.php
@@ -266,10 +266,8 @@ class Session implements SessionInterface
         }
 
         $headers = [
-            [
-                'X-Stream' => true,
-                'Content-Type' => 'application/json',
-            ],
+            'X-Stream' => true,
+            'Content-Type' => 'application/json',
         ];
 
         $body = json_encode([


### PR DESCRIPTION
Double array are nicely handled by Guzzle6 but are not according to specification for PSR7. 

More lightweight/strict clients (like php-http/curl-client) will fail because of this. 

