### PR TITLE
Fix for test setup when neo4j does not run with default settings

### DIFF
--- a/tests/Example/ExampleTestCase.php
+++ b/tests/Example/ExampleTestCase.php
@@ -22,8 +22,18 @@ abstract class ExampleTestCase extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
+        $boltUrl = 'bolt://localhost';
+        if (isset($_ENV['NEO4J_USER'])) {
+            $boltUrl = sprintf(
+                'bolt://%s:%s@%s',
+                getenv('NEO4J_USER'),
+                getenv('NEO4J_PASSWORD'),
+                getenv('NEO4J_HOST')
+            );
+        }
+
         $this->client = ClientBuilder::create()
-            ->addConnection('default', 'bolt://localhost')
+            ->addConnection('default', $boltUrl)
             ->build();
     }
 

--- a/tests/Integration/BuildWithEventListenersIntegrationTest.php
+++ b/tests/Integration/BuildWithEventListenersIntegrationTest.php
@@ -22,11 +22,28 @@ use GraphAware\Neo4j\Client\Neo4jClientEvents;
  */
 class BuildWithEventListenersIntegrationTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @return string
+     */
+    private function createBoltUrl()
+    {
+        $boltUrl = 'bolt://localhost';
+        if (isset($_ENV['NEO4J_USER'])) {
+            $boltUrl = sprintf(
+                'bolt://%s:%s@%s',
+                getenv('NEO4J_USER'),
+                getenv('NEO4J_PASSWORD'),
+                getenv('NEO4J_HOST')
+            );
+        }
+        return $boltUrl;
+    }
+
     public function testListenersAreRegistered()
     {
         $listener = new EventListener();
         $client = ClientBuilder::create()
-            ->addConnection('default', 'bolt://localhost')
+            ->addConnection('default', $this->createBoltUrl())
             ->registerEventListener(Neo4jClientEvents::NEO4J_PRE_RUN, [$listener, 'onPreRun'])
             ->registerEventListener(Neo4jClientEvents::NEO4J_POST_RUN, [$listener, 'onPostRun'])
             ->registerEventListener(Neo4jClientEvents::NEO4J_ON_FAILURE, [$listener, 'onFailure'])
@@ -41,7 +58,7 @@ class BuildWithEventListenersIntegrationTest extends \PHPUnit_Framework_TestCase
     {
         $listener = new EventListener();
         $client = ClientBuilder::create()
-            ->addConnection('default', 'bolt://localhost')
+            ->addConnection('default', $this->createBoltUrl())
             ->registerEventListener(Neo4jClientEvents::NEO4J_ON_FAILURE, [$listener, 'onFailure'])
             ->build();
 

--- a/tests/Integration/ClientGetExceptionIntegrationTest.php
+++ b/tests/Integration/ClientGetExceptionIntegrationTest.php
@@ -18,8 +18,18 @@ class ClientGetExceptionIntegrationTest extends \PHPUnit_Framework_TestCase
 {
     public function testExceptionHandling()
     {
+        $boltUrl = 'bolt://localhost';
+        if (isset($_ENV['NEO4J_USER'])) {
+            $boltUrl = sprintf(
+                'bolt://%s:%s@%s',
+                getenv('NEO4J_USER'),
+                getenv('NEO4J_PASSWORD'),
+                getenv('NEO4J_HOST')
+            );
+        }
+
         $client = ClientBuilder::create()
-            ->addConnection('default', 'bolt://localhost')
+            ->addConnection('default', $boltUrl)
             ->build();
 
         $this->setExpectedException(Neo4jException::class);

--- a/tests/Integration/ClientSetupIntegrationTest.php
+++ b/tests/Integration/ClientSetupIntegrationTest.php
@@ -115,8 +115,20 @@ class ClientSetupIntegrationTest extends \PHPUnit_Framework_TestCase
 
     public function testSendWriteUseMasterIfAvailable()
     {
+        $httpUri = 'http://localhost:7474';
+        if (isset($_ENV['NEO4J_USER'])) {
+            $httpUri = sprintf(
+                '%s://%s:%s@%s:%s',
+                getenv('NEO4J_SCHEMA'),
+                getenv('NEO4J_USER'),
+                getenv('NEO4J_PASSWORD'),
+                getenv('NEO4J_HOST'),
+                getenv('NEO4J_PORT')
+            );
+        }
+
         $connectionManager = $this->prophesize(ConnectionManager::class);
-        $conn = new Connection('default', 'http://localhost:7474', null, 5);
+        $conn = new Connection('default', $httpUri, null, 5);
         $connectionManager->getMasterConnection()->willReturn($conn);
         $connectionManager->getMasterConnection()->shouldBeCalled();
 

--- a/tests/Integration/IntegrationTestCase.php
+++ b/tests/Integration/IntegrationTestCase.php
@@ -37,7 +37,7 @@ class IntegrationTestCase extends \PHPUnit_Framework_TestCase
         $boltUrl = 'bolt://localhost';
         if (isset($_ENV['NEO4J_USER'])) {
             $boltUrl = sprintf(
-                'bolt://%s:%s@%',
+                'bolt://%s:%s@%s',
                 getenv('NEO4J_USER'),
                 getenv('NEO4J_PASSWORD'),
                 getenv('NEO4J_HOST')


### PR DESCRIPTION
Some tests did not run when neo4j was running

- requiring authentication
- not on default port
- not on default host (localhost)

There was also a minor issue in `GraphAware\Neo4j\Client\Tests\Integration\IntegrationTestCase::setUp` when creating a custom Bolt URL (missing `s` at the end).