### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can:
 Add the library to your composer dependencies :
 
 ```bash
-composer require graphaware/neo4j-php-client:^4.0
+composer require "graphaware/neo4j-php-client:^4.0"
 ```
 
 Require the composer autoloader, configure your connection by providing a connection alias and your connection settings :


### PR DESCRIPTION
On some shells, the `composer require` line need quotes to work.

```bash
$ composer require graphaware/neo4j-php-client:^4.0
zsh: no matches found: graphaware/neo4j-php-client:^4.0
```

Now it works for everybody!