### PR TITLE
Symphony EventDispatcher update to v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
       "ext-mbstring": "*",
       "graphaware/neo4j-common": "^3.4",
       "graphaware/neo4j-bolt": "^1.5",
-      "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0",
+      "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0 || ^5.0",
       "myclabs/php-enum": "^1.4",
       "php-http/httplug": "^1.0",
       "php-http/message-factory": "^1.0",

--- a/src/Client.php
+++ b/src/Client.php
@@ -61,14 +61,14 @@ class Client implements ClientInterface
         $connection = $this->connectionManager->getConnection($connectionAlias);
         $params = null !== $parameters ? $parameters : [];
         $statement = Statement::create($query, $params, $tag);
-        $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_PRE_RUN, new PreRunEvent([$statement]));
+        $this->eventDispatcher->dispatch(new PreRunEvent([$statement]), Neo4jClientEvents::NEO4J_PRE_RUN);
 
         try {
             $result = $connection->run($query, $parameters, $tag);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_POST_RUN, new PostRunEvent(ResultCollection::withResult($result)));
+            $this->eventDispatcher->dispatch(new PostRunEvent(ResultCollection::withResult($result)), Neo4jClientEvents::NEO4J_POST_RUN);
         } catch (Neo4jException $e) {
             $event = new FailureEvent($e);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_ON_FAILURE, $event);
+            $this->eventDispatcher->dispatch($event, Neo4jClientEvents::NEO4J_ON_FAILURE);
 
             if ($event->shouldThrowException()) {
                 throw $e;
@@ -141,14 +141,14 @@ class Client implements ClientInterface
             $pipeline->push($statement->text(), $statement->parameters(), $statement->getTag());
         }
 
-        $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_PRE_RUN, new PreRunEvent($stack->statements()));
+        $this->eventDispatcher->dispatch(new PreRunEvent($stack->statements()), Neo4jClientEvents::NEO4J_PRE_RUN);
 
         try {
             $results = $pipeline->run();
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_POST_RUN, new PostRunEvent($results));
+            $this->eventDispatcher->dispatch(new PostRunEvent($results), Neo4jClientEvents::NEO4J_POST_RUN);
         } catch (Neo4jException $e) {
             $event = new FailureEvent($e);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_ON_FAILURE, $event);
+            $this->eventDispatcher->dispatch($event, Neo4jClientEvents::NEO4J_ON_FAILURE);
 
             if ($event->shouldThrowException()) {
                 throw $e;

--- a/src/Event/FailureEvent.php
+++ b/src/Event/FailureEvent.php
@@ -12,7 +12,7 @@
 namespace GraphAware\Neo4j\Client\Event;
 
 use GraphAware\Neo4j\Client\Exception\Neo4jExceptionInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class FailureEvent extends Event
 {

--- a/src/Event/PostRunEvent.php
+++ b/src/Event/PostRunEvent.php
@@ -12,7 +12,7 @@
 namespace GraphAware\Neo4j\Client\Event;
 
 use GraphAware\Common\Result\ResultCollection;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class PostRunEvent extends Event
 {

--- a/src/Event/PreRunEvent.php
+++ b/src/Event/PreRunEvent.php
@@ -12,7 +12,7 @@
 namespace GraphAware\Neo4j\Client\Event;
 
 use GraphAware\Common\Cypher\StatementInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class PreRunEvent extends Event
 {

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -78,16 +78,16 @@ class Transaction
             $this->driverTransaction->begin();
         }
         $stmt = Statement::create($statement, $parameters, $tag);
-        $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_PRE_RUN, new PreRunEvent([$stmt]));
+        $this->eventDispatcher->dispatch(new PreRunEvent([$stmt]), Neo4jClientEvents::NEO4J_PRE_RUN);
         try {
             $result = $this->driverTransaction->run(Statement::create($statement, $parameters, $tag));
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_POST_RUN, new PostRunEvent(ResultCollection::withResult($result)));
+            $this->eventDispatcher->dispatch(new PostRunEvent(ResultCollection::withResult($result)), Neo4jClientEvents::NEO4J_POST_RUN);
         } catch (MessageFailureException $e) {
             $exception = new Neo4jException($e->getMessage());
             $exception->setNeo4jStatusCode($e->getStatusCode());
 
             $event = new FailureEvent($exception);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_ON_FAILURE, $event);
+            $this->eventDispatcher->dispatch($event, Neo4jClientEvents::NEO4J_ON_FAILURE);
             if ($event->shouldThrowException()) {
                 throw $exception;
             }
@@ -126,16 +126,16 @@ class Transaction
             $sts[] = $statement;
         }
 
-        $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_PRE_RUN, new PreRunEvent($stack->statements()));
+        $this->eventDispatcher->dispatch(new PreRunEvent($stack->statements()), Neo4jClientEvents::NEO4J_PRE_RUN);
         try {
             $results = $this->driverTransaction->runMultiple($sts);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_POST_RUN, new PostRunEvent($results));
+            $this->eventDispatcher->dispatch(new PostRunEvent($results), Neo4jClientEvents::NEO4J_POST_RUN);
         } catch (MessageFailureException $e) {
             $exception = new Neo4jException($e->getMessage());
             $exception->setNeo4jStatusCode($e->getStatusCode());
 
             $event = new FailureEvent($exception);
-            $this->eventDispatcher->dispatch(Neo4jClientEvents::NEO4J_ON_FAILURE, $event);
+            $this->eventDispatcher->dispatch($event, Neo4jClientEvents::NEO4J_ON_FAILURE);
             if ($event->shouldThrowException()) {
                 throw $exception;
             }


### PR DESCRIPTION
@ikwattro 
According to https://github.com/symfony/event-dispatcher/blob/master/CHANGELOG.md

Only this is changed actually 
 - The Event class has been removed in favor of Symfony\Contracts\EventDispatcher\Event.
- The signature of the EventDispatcherInterface::dispatch() method has been changed to dispatch($event, string $eventName = null): object.


And composer.json to pull new event dispatcher